### PR TITLE
Truncates large backtraces to 5kb

### DIFF
--- a/lib/collector.coffee
+++ b/lib/collector.coffee
@@ -11,9 +11,9 @@ module.exports =
     # Public: Returns an object containing all data collected for a specific
     # error.
     getDataForError: (message, url, line) ->
+      message = message.substring(0, 5*1024)
       backtrace = "#{message}\n"
       backtrace += "at (#{url}:#{line})"
-      backtrace = backtrace.substring(0, 5*1024)
 
       data =
         backtrace: backtrace

--- a/spec/collector-spec.coffee
+++ b/spec/collector-spec.coffee
@@ -15,5 +15,7 @@ describe "Collector", ->
 
     it "truncates large backtraces", ->
       largeString = Array(1024*5).join("a")
-      data = subject.getDataForError(largeString, 'file.coffee', 1)
-      expect(data.backtrace.length).toBe 5*1024
+      url = 'file.coffee'
+      line = 1
+      data = subject.getDataForError(largeString, url, line)
+      expect(data.backtrace.length).toBe (5*1024 + 6 + url.length + line.toString().length)


### PR DESCRIPTION
Makes sure that our backtraces have an upper limit on their size, fixes #3.

@derekgr @alindeman Does this work for you both? Anything else I should add while I'm in here.
