### PR TITLE
Enhance in project

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -35,11 +35,11 @@ class Reporter
       for line in coffeestack.convertStackTrace(error.stack).split('\n')
         if match = atLinePattern.exec(line)
           stacktrace.push
-            file: match[3]
+            file: match[3].replace(/(.*[\/\\]Resources[\/\\])/, '')
             method: match[2].replace(/^(HTMLDocument|HTML[^\.]*Element|Object)\./, '')
             columnNumber: parseInt(match[5])
             lineNumber: parseInt(match[4])
-            inProject: true
+            inProject: !/node_modules/.test(match[3])
     else
       stacktrace.push
         file: source

--- a/spec/reporter-spec.coffee
+++ b/spec/reporter-spec.coffee
@@ -16,8 +16,8 @@ describe "Reporter", ->
       error =
         stack: """
           Error: whoops
-            at HTMLDivElement.<anonymous> (/Users/me/atom/node_modules/fuzzy-finder.coffee:10:15)
-            at HTMLDivElement.jQuery.event.dispatch (/Users/me/atom/node_modules/space-pen/vendor/jquery.js:4676:9)
+            at HTMLDivElement.<anonymous> (/Users/me/atom/Resources/app/fuzzy-finder.coffee:10:15)
+            at HTMLDivElement.jQuery.event.dispatch (/Users/me/atom/Resources/node_modules/space-pen/vendor/jquery.js:4676:9)
         """
       Reporter.send('message', filePath, 1, 2, error)
       expect(Reporter.request).toHaveBeenCalled()
@@ -35,18 +35,18 @@ describe "Reporter", ->
       expect(body.events[0].exceptions[0].message).toEqual 'message'
       expect(body.events[0].exceptions[0].stacktrace).toEqual [
         {
-          file: '/Users/me/atom/node_modules/fuzzy-finder.coffee'
+          file: 'app/fuzzy-finder.coffee'
           method: '<anonymous>'
           columnNumber: 15
           lineNumber: 10
           inProject: true
         }
         {
-          file: '/Users/me/atom/node_modules/space-pen/vendor/jquery.js'
+          file: 'node_modules/space-pen/vendor/jquery.js'
           method: 'jQuery.event.dispatch'
           columnNumber: 9
           lineNumber: 4676
-          inProject: true
+          inProject: false
         }
       ]
 


### PR DESCRIPTION
This PR should massively improve your Bugsnag dashboard by doing the following:
- Set any stacktrace lines which do _not_ contain `node_modules` as `inProject`
- Strips common path information from the start of stacktrace lines

Things to consider:
- You might want to change the inProject regex to instead be a whitelist of paths that you care about, I've simply marked all node_modules as not in project.
- The regex for stripping common path information probably won't work on windows, so you'll need to update that before you release the windows version
