### PR TITLE
Support assertion reporting and refactor reporting in general

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 Reporter = null
+NewReporter = null
 
 module.exports =
   activate: ->
@@ -8,6 +9,9 @@ module.exports =
     @uncaughtErrorSubscription = atom.onDidThrowError ({message, url, line, column, originalError}) ->
       Reporter ?= require './reporter'
       Reporter.send(message, url, line, column, originalError)
+
+      NewReporter ?= require './new-reporter'
+      NewReporter.reportUncaughtException(originalError)
 
   deactivate: ->
     @uncaughtErrorSubscription?.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,13 +14,23 @@ module.exports =
       Reporter ?= require './reporter'
       Reporter.send(message, url, line, column, originalError)
 
-      NewReporter ?= require './new-reporter'
-      NewReporter.reportUncaughtException(originalError)
+      try
+        NewReporter ?= require './new-reporter'
+        NewReporter.reportUncaughtException(originalError)
+      catch secondaryException
+        try
+          console.error "Error reporting uncaught exception", secondaryException
+          NewReporter.reportUncaughtException(secondaryException)
 
     if atom.onDidFailAssertion?
       @subscriptions.add atom.onDidFailAssertion (error) ->
-        NewReporter ?= require './new-reporter'
-        NewReporter.reportFailedAssertion(error)
+        try
+          NewReporter ?= require './new-reporter'
+          NewReporter.reportFailedAssertion(error)
+        catch secondaryException
+          try
+            console.error "Error reporting assertion failure", secondaryException
+            NewReporter.reportUncaughtException(secondaryException)
 
   deactivate: ->
     @subscriptions?.dispose()

--- a/lib/new-reporter.coffee
+++ b/lib/new-reporter.coffee
@@ -1,0 +1,79 @@
+_ = require 'underscore-plus'
+os = require 'os'
+request = require 'request'
+stackTrace = require 'stack-trace'
+
+StackTraceCache = new WeakMap
+
+buildNotificationJSON = (error, params) ->
+  apiKey: '7ddca14cb60cbd1cd12d1b252473b076'
+  notifier:
+    name: 'Atom'
+    version: params.appVersion
+    url: 'https://www.atom.io'
+  events: [{
+    payloadVersion: "2"
+    exceptions: [buildExceptionJSON(error, params.projectRoot)]
+    severity: params.severity
+    user:
+      id: params.userId
+    app:
+      version: params.appVersion
+      releaseStage: params.releaseStage
+    device:
+      osVersion: params.osVersion
+    metaData: error.metadata
+  }]
+
+buildExceptionJSON = (error, projectRoot) ->
+  errorClass: error.constructor.name
+  message: error.message
+  stacktrace: buildStackTraceJSON(error, projectRoot)
+
+buildStackTraceJSON = (error, projectRoot) ->
+  projectRootRegex = ///^#{_.escapeRegExp(projectRoot)}[\/\\]///i
+  parseStackTrace(error).map (callSite) ->
+    file: callSite.getFileName().replace(projectRootRegex, '')
+    method: callSite.getMethodName() ? callSite.getFunctionName() ? "none"
+    lineNumber: callSite.getLineNumber()
+    columnNumber: callSite.getColumnNumber()
+    inProject: not /node_modules/.test(callSite.getFileName())
+
+getDefaultNotificationParams = ->
+  userId: atom.config.get('exception-reporting.userId')
+  appVersion: atom.getVersion()
+  releaseStage: if atom.isReleasedVersion() then 'x-production' else 'x-development'
+  projectRoot: atom.getLoadSettings().resourcePath
+  osVersion: "#{os.platform()}-#{os.arch()}-#{os.release()}"
+
+performRequest = (json) ->
+  options =
+    method: 'POST'
+    url: 'https://notify.bugsnag.com'
+    headers: 'Content-Type': 'application/json'
+    body: JSON.stringify(json)
+  request options, -> # Empty callback prevents errors from going to the console
+
+shouldReport = (error) ->
+  # return false if atom.inDevMode()
+  if topFrame = parseStackTrace(error)[0]
+    # only report exceptions that originate from the application bundle
+    topFrame.getFileName().indexOf(atom.getLoadSettings().resourcePath) is 0
+  else
+    false
+
+parseStackTrace = (error) ->
+  if callSites = StackTraceCache.get(error)
+    callSites
+  else
+    callSites = stackTrace.parse(error)
+    StackTraceCache.set(error, callSites)
+    callSites
+
+exports.reportUncaughtException = (error) ->
+  return unless shouldReport(error)
+
+  params = getDefaultNotificationParams()
+  params.severity = "error"
+  json = buildNotificationJSON(error, params)
+  performRequest(json)

--- a/lib/new-reporter.coffee
+++ b/lib/new-reporter.coffee
@@ -77,3 +77,11 @@ exports.reportUncaughtException = (error) ->
   params.severity = "error"
   json = buildNotificationJSON(error, params)
   performRequest(json)
+
+exports.reportFailedAssertion = (error) ->
+  return unless shouldReport(error)
+
+  params = getDefaultNotificationParams()
+  params.severity = "warning"
+  json = buildNotificationJSON(error, params)
+  performRequest(json)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "atom": ">0.48.0"
   },
   "dependencies": {
-    "bugsnag": "^1.6.5",
     "coffeestack": "^1",
     "guid": "0.0.11",
     "request": "^2.33.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "atom": ">0.48.0"
   },
   "dependencies": {
+    "bugsnag": "^1.6.5",
+    "coffeestack": "^1",
     "guid": "0.0.11",
     "request": "^2.33.0",
-    "coffeestack": "^1",
     "underscore-plus": "1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
The primary goal of this PR is to report assertion failures, captured via `atom.onDidFailAssertion` once atom/atom#7350 lands. These kinds of failures are reported at the severity level of `warning` since they are silent and don't actually stop the user's workflow.

To support this feature, I also overhauled our reporter. Since this is a sensitive area and we really need exception reporting to continue working at all costs, I added a completely new reporter that reports to the `x-production` and `x-development` environments on Bugsnag. Once we see it's working smoothly for a couple releases, we can drop the old reporter and transition to using the new one exclusively.