### PR TITLE
Use slash as path separator regardless of OS

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -34,7 +34,7 @@ buildExceptionJSON = (error, projectRoot) ->
 buildStackTraceJSON = (error, projectRoot) ->
   projectRootRegex = ///^#{_.escapeRegExp(projectRoot)}[\/\\]///i
   parseStackTrace(error).map (callSite) ->
-    file: callSite.getFileName().replace(projectRootRegex, '')
+    file: callSite.getFileName().replace(projectRootRegex, '').replace(/\\/g, "/")
     method: callSite.getMethodName() ? callSite.getFunctionName() ? "none"
     lineNumber: callSite.getLineNumber()
     columnNumber: callSite.getColumnNumber()

--- a/spec/reporter-spec.coffee
+++ b/spec/reporter-spec.coffee
@@ -33,6 +33,7 @@ describe "Reporter", ->
 
       # asserting the correct path is difficult on CI. let's do 'close enough'.
       expect(body.events[0].exceptions[0].stacktrace[0].file).toMatch /reporter-spec/
+      expect(body.events[0].exceptions[0].stacktrace[0].file).not.toMatch /\\/
       delete body.events[0].exceptions[0].stacktrace[0].file
       delete body.events[0].exceptions[0].stacktrace[0].inProject
 
@@ -158,6 +159,7 @@ describe "Reporter", ->
 
       # asserting the correct path is difficult on CI. let's do 'close enough'.
       expect(body.events[0].exceptions[0].stacktrace[0].file).toMatch /reporter-spec/
+      expect(body.events[0].exceptions[0].stacktrace[0].file).not.toMatch /\\/
       delete body.events[0].exceptions[0].stacktrace[0].file
       delete body.events[0].exceptions[0].stacktrace[0].inProject
 


### PR DESCRIPTION
I was looking at things in bugsnag today and noticed this:

<img width="517" alt="screen shot 2015-09-11 at 14 51 59" src="https://cloud.githubusercontent.com/assets/38924/9816444/5c2b5820-589d-11e5-9a0b-16c1d2596112.png">

Seems like bugsnag is not smart enough to figure out that these should be the same exceptions, so it doesn't group them (the errorClass is the same, the line is the same, and the path is the same if you ignore OS-specific separators). 

Let's help bugsnag with grouping these correctly by using the same separator regardless of OS when sending exceptions to bugsnag. That will give us a more accurate picture of the exceptions that are happening.

cc @kevinsawicki @nathansobo for :thought_balloon: and :eyes: 