### PR TITLE
Set notifier version to version of bugsnag-atom

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -3,6 +3,7 @@ os = require 'os'
 request = require 'request'
 stackTrace = require 'stack-trace'
 API_KEY = '7ddca14cb60cbd1cd12d1b252473b076'
+LIB_VERSION = require('../package.json')['version']
 
 StackTraceCache = new WeakMap
 
@@ -10,7 +11,7 @@ buildNotificationJSON = (error, params) ->
   apiKey: API_KEY
   notifier:
     name: 'Atom'
-    version: params.appVersion
+    version: LIB_VERSION
     url: 'https://www.atom.io'
   events: [{
     payloadVersion: "2"
@@ -142,3 +143,4 @@ exports.setRequestFunction = (requestFunction) ->
   request = requestFunction
 
 exports.API_KEY = API_KEY
+exports.LIB_VERSION = LIB_VERSION

--- a/spec/reporter-spec.coffee
+++ b/spec/reporter-spec.coffee
@@ -41,7 +41,7 @@ describe "Reporter", ->
         "apiKey": Reporter.API_KEY
         "notifier": {
           "name": "Atom",
-          "version": atom.getVersion(),
+          "version": Reporter.LIB_VERSION,
           "url": "https://www.atom.io"
         },
         "events": [
@@ -167,7 +167,7 @@ describe "Reporter", ->
         "apiKey": Reporter.API_KEY
         "notifier": {
           "name": "Atom",
-          "version": atom.getVersion(),
+          "version": Reporter.LIB_VERSION,
           "url": "https://www.atom.io"
         },
         "events": [


### PR DESCRIPTION
The version number in `notifier.version` should be the version of the notifier library, rather than the version of the app, which is stored in each event's `app.version`. 
~~Do you automate updating the version in some way? If so I'll amend the PR to update that as well.~~

Patched to load the version from package.json