### PR TITLE
Only send telemetry with consent

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -56,9 +56,8 @@ performRequest = (json) ->
   })
 
 shouldReport = (error) ->
-  return false unless atom.config.get('core.telemetryConsent') is 'limited'
-  return true if global.alwaysReportToBugsnag # Used to test reports in dev mode
   return true if exports.alwaysReport # Used in specs
+  return false unless atom.config.get('core.telemetryConsent') is 'limited'
   return false if atom.inDevMode()
 
   if topFrame = parseStackTrace(error)[0]

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -56,6 +56,7 @@ performRequest = (json) ->
   })
 
 shouldReport = (error) ->
+  return false unless atom.config.get('core.telemetryConsent') is 'limited'
   return true if global.alwaysReportToBugsnag # Used to test reports in dev mode
   return true if exports.alwaysReport # Used in specs
   return false if atom.inDevMode()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "exception-reporting",
   "main": "./lib/main",
   "version": "0.38.4",
-  "description": "Reports uncaught Atom exceptions to bugsnag.com",
+  "description": "Reports uncaught Atom exceptions to the Atom team via bugsnag.com",
   "repository": "https://github.com/atom/exception-reporting",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
All parts are required for this to work correctly;

- https://github.com/atom/atom/pull/12281
- https://github.com/atom/metrics/pull/66
- https://github.com/atom/exception-reporting/pull/20
- https://github.com/atom/about/pull/37
- https://github.com/atom/welcome/pull/48
