### PR TITLE
Hard-code LIB_VERSION for now because it breaks inside packaged Atom

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -2,7 +2,10 @@ _ = require 'underscore-plus'
 os = require 'os'
 stackTrace = require 'stack-trace'
 API_KEY = '7ddca14cb60cbd1cd12d1b252473b076'
-LIB_VERSION = require('../package.json')['version']
+
+# TODO: Replace with the following when we stop deleting package.json for bundled packages. Sorry world.
+# LIB_VERSION = require('../package.json')['version']
+LIB_VERSION = '0.38.2'
 
 request = window.fetch
 StackTraceCache = new WeakMap


### PR DESCRIPTION
We [delete the package.json of all bundled packages during our slug compilation step](https://github.com/atom/atom/blob/62fa56e533e9d16ce8cf5dc0f3ebb173e15881c3/build/tasks/compile-packages-slug-task.coffee#L57). I don’t feel comfortable changing that on stable, but we’ll need exception reporting to work in the meantime. Once we change this to retain this information, we can restore the original code. The [original PR](https://github.com/atom/atom/pull/3917) claims we delete the originals to make the bundle "a little leaner", so I think we can ultimately remove the deletion code.

/cc @lee-dohm @kattrali 