### PR TITLE
Include messages of previous exceptions in reported metadata

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,15 @@
 
 import {CompositeDisposable} from 'atom'
 
-let Reporter = null
+let reporter
+
+function getReporter () {
+  if (!reporter) {
+    const Reporter = require('./reporter')
+    reporter = new Reporter()
+  }
+  return reporter
+}
 
 export default {
   activate() {
@@ -14,12 +22,11 @@ export default {
 
     this.subscriptions.add(atom.onDidThrowError(({message, url, line, column, originalError}) => {
       try {
-        Reporter = Reporter || require('./reporter')
-        Reporter.reportUncaughtException(originalError)
+        getReporter().reportUncaughtException(originalError)
       } catch (secondaryException) {
         try {
           console.error("Error reporting uncaught exception", secondaryException)
-          Reporter.reportUncaughtException(secondaryException)
+          getReporter().reportUncaughtException(secondaryException)
         } catch (error) { }
       }
     })
@@ -28,12 +35,11 @@ export default {
     if (atom.onDidFailAssertion != null) {
       this.subscriptions.add(atom.onDidFailAssertion(error => {
         try {
-          Reporter = Reporter || require('./reporter')
-          Reporter.reportFailedAssertion(error)
+          getReporter().reportFailedAssertion(error)
         } catch (secondaryException) {
           try {
             console.error("Error reporting assertion failure", secondaryException)
-            Reporter.reportUncaughtException(secondaryException)
+            getReporter().reportUncaughtException(secondaryException)
           } catch (error) {}
         }
       })

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -5,221 +5,227 @@ import os from 'os'
 import stackTrace from 'stack-trace'
 import fs from 'fs-plus'
 
-let API_KEY = '7ddca14cb60cbd1cd12d1b252473b076'
-let LIB_VERSION = require('../package.json')['version']
+const API_KEY = '7ddca14cb60cbd1cd12d1b252473b076'
+const LIB_VERSION = require('../package.json')['version']
+const StackTraceCache = new WeakMap()
 
-let request = window.fetch
-let StackTraceCache = new WeakMap()
+export default class Reporter {
+  constructor (params = {}) {
+    this.request = params.request || window.fetch
+    this.alwaysReport = params.hasOwnProperty('alwaysReport') ? params.alwaysReport : false
+  }
 
-let buildNotificationJSON = (error, params) =>
-  ({
-    apiKey: API_KEY,
-    notifier: {
-      name: 'Atom',
-      version: LIB_VERSION,
-      url: 'https://www.atom.io'
-    },
-    events: [{
-      payloadVersion: "2",
-      exceptions: [buildExceptionJSON(error, params.projectRoot)],
-      severity: params.severity,
-      user: {
-        id: params.userId
-      },
-      app: {
-        version: params.appVersion,
-        releaseStage: params.releaseStage
-      },
-      device: {
-        osVersion: params.osVersion
-      },
-      metaData: error.metadata
-    }]
-  })
-
-let buildExceptionJSON = (error, projectRoot) =>
-  ({
-    errorClass: error.constructor.name,
-    message: error.message,
-    stacktrace: buildStackTraceJSON(error, projectRoot)
-  })
-
-
-let buildStackTraceJSON = (error, projectRoot) => {
-  let projectRootRegex = new RegExp(`^${_.escapeRegExp(projectRoot)}[\\/\\\\]`, 'i')
-  return parseStackTrace(error).map(callSite => {
+  buildNotificationJSON (error, params) {
     return {
-      file: normalizePath(callSite.getFileName()),
-      method: callSite.getMethodName() || callSite.getFunctionName() || "none",
-      lineNumber: callSite.getLineNumber(),
-      columnNumber: callSite.getColumnNumber(),
-      inProject: !/node_modules/.test(callSite.getFileName())
-    }
-  })
-}
-
-let normalizePath = path => {
-  return path.replace('file:///', '')                         // Randomly inserted file url protocols
-             .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
-             .replace(fs.getHomeDirectory(), '~')             // Remove users home dir for apm-dev'ed packages
-             .replace(/\\/g, '/')                             // Switch \ back to / for everyone
-             .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
-}
-
-let getDefaultNotificationParams = () =>
-  ({
-    userId: atom.config.get('exception-reporting.userId'),
-    appVersion: atom.getVersion(),
-    releaseStage: getReleaseChannel(atom.getVersion()),
-    projectRoot: atom.getLoadSettings().resourcePath,
-    osVersion: `${os.platform()}-${os.arch()}-${os.release()}`
-  })
-
-
-let getReleaseChannel = version =>
-  (version.indexOf('beta') > -1)
-    ? 'beta'
-    : (version.indexOf('dev') > -1)
-    ? 'dev'
-    : 'stable'
-
-let performRequest = json => {
-  request('https://notify.bugsnag.com', {
-    method: 'POST',
-    headers: new Headers({'Content-Type': 'application/json'}),
-    body: JSON.stringify(json)
-  })
-}
-
-let shouldReport = error => {
-  if (exports.alwaysReport) return true // Used in specs
-  if (atom.config.get('core.telemetryConsent') !== 'limited') return false
-  if (atom.inDevMode()) return false
-
-  let topFrame = parseStackTrace(error)[0]
-  return topFrame &&
-         topFrame.getFileName() &&
-         topFrame.getFileName().indexOf(atom.getLoadSettings().resourcePath) === 0
-}
-
-let parseStackTrace = error => {
-  let callSites = StackTraceCache.get(error)
-  if (callSites) {
-    return callSites
-  } else {
-    callSites = stackTrace.parse(error)
-    StackTraceCache.set(error, callSites)
-    return callSites
-  }
-}
-
-let requestPrivateMetadataConsent = (error, message, reportFn) => {
-  let notification, dismissSubscription
-
-  let reportWithoutPrivateMetadata = () => {
-    if (dismissSubscription) {
-      dismissSubscription.dispose()
-    }
-    delete error.privateMetadata
-    delete error.privateMetadataDescription
-    reportFn(error)
-    if (notification) {
-      notification.dismiss()
-    }
-  }
-
-  let reportWithPrivateMetadata = () => {
-    if (error.metadata == null) {
-      error.metadata = {}
-    }
-    for (let key in error.privateMetadata) {
-      let value = error.privateMetadata[key]
-      error.metadata[key] = value
-    }
-    reportWithoutPrivateMetadata()
-  }
-
-  let name = error.privateMetadataRequestName
-  if (name != null && name != undefined) {
-    if (localStorage.getItem(`private-metadata-request:${name}`)) {
-      return reportWithoutPrivateMetadata(error)
-    } else {
-      localStorage.setItem(`private-metadata-request:${name}`, true)
-    }
-  }
-
-  notification = atom.notifications.addInfo(message, {
-    detail: error.privateMetadataDescription,
-    description: "Are you willing to submit this information to a private server for debugging purposes?",
-    dismissable: true,
-    buttons: [
-      {
-        text: "No",
-        onDidClick: reportWithoutPrivateMetadata
+      apiKey: API_KEY,
+      notifier: {
+        name: 'Atom',
+        version: LIB_VERSION,
+        url: 'https://www.atom.io'
       },
-      {
-        text: "Yes, Submit for Debugging",
-        onDidClick: reportWithPrivateMetadata
+      events: [{
+        payloadVersion: "2",
+        exceptions: [this.buildExceptionJSON(error, params.projectRoot)],
+        severity: params.severity,
+        user: {
+          id: params.userId
+        },
+        app: {
+          version: params.appVersion,
+          releaseStage: params.releaseStage
+        },
+        device: {
+          osVersion: params.osVersion
+        },
+        metaData: error.metadata
+      }]
+    }
+  }
+
+  buildExceptionJSON (error, projectRoot) {
+    return {
+      errorClass: error.constructor.name,
+      message: error.message,
+      stacktrace: this.buildStackTraceJSON(error, projectRoot)
+    }
+  }
+
+  buildStackTraceJSON (error, projectRoot) {
+    return this.parseStackTrace(error).map(callSite => {
+      return {
+        file: this.normalizePath(callSite.getFileName()),
+        method: callSite.getMethodName() || callSite.getFunctionName() || "none",
+        lineNumber: callSite.getLineNumber(),
+        columnNumber: callSite.getColumnNumber(),
+        inProject: !/node_modules/.test(callSite.getFileName())
       }
-    ]
-  })
+    })
+  }
 
-  dismissSubscription = notification.onDidDismiss(reportWithoutPrivateMetadata)
-}
+  normalizePath (path) {
+    return path.replace('file:///', '')                         // Randomly inserted file url protocols
+               .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
+               .replace(fs.getHomeDirectory(), '~')             // Remove users home dir for apm-dev'ed packages
+               .replace(/\\/g, '/')                             // Switch \ back to / for everyone
+               .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
+  }
 
-let addPackageMetadata = error => {
-  let activePackages = atom.packages.getActivePackages()
-  if (activePackages.length > 0) {
-    let userPackages = {}
-    let bundledPackages = {}
-    for (let pack of atom.packages.getActivePackages()) {
-      if (/\/app\.asar\//.test(pack.path)) {
-        bundledPackages[pack.name] = pack.metadata.version
-      } else {
-        userPackages[pack.name] = pack.metadata.version
+  getDefaultNotificationParams () {
+    return {
+      userId: atom.config.get('exception-reporting.userId'),
+      appVersion: atom.getVersion(),
+      releaseStage: this.getReleaseChannel(atom.getVersion()),
+      projectRoot: atom.getLoadSettings().resourcePath,
+      osVersion: `${os.platform()}-${os.arch()}-${os.release()}`
+    }
+  }
+
+  getReleaseChannel (version) {
+    return (version.indexOf('beta') > -1)
+      ? 'beta'
+      : (version.indexOf('dev') > -1)
+        ? 'dev'
+        : 'stable'
+  }
+
+  performRequest (json) {
+    this.request('https://notify.bugsnag.com', {
+      method: 'POST',
+      headers: new Headers({'Content-Type': 'application/json'}),
+      body: JSON.stringify(json)
+    })
+  }
+
+  shouldReport (error) {
+    if (this.alwaysReport) return true // Used in specs
+    if (atom.config.get('core.telemetryConsent') !== 'limited') return false
+    if (atom.inDevMode()) return false
+
+    let topFrame = this.parseStackTrace(error)[0]
+    return topFrame &&
+           topFrame.getFileName() &&
+           topFrame.getFileName().indexOf(atom.getLoadSettings().resourcePath) === 0
+  }
+
+  parseStackTrace (error) {
+    let callSites = StackTraceCache.get(error)
+    if (callSites) {
+      return callSites
+    } else {
+      callSites = stackTrace.parse(error)
+      StackTraceCache.set(error, callSites)
+      return callSites
+    }
+  }
+
+  requestPrivateMetadataConsent (error, message, reportFn) {
+    let notification, dismissSubscription
+
+    function reportWithoutPrivateMetadata () {
+      if (dismissSubscription) {
+        dismissSubscription.dispose()
+      }
+      delete error.privateMetadata
+      delete error.privateMetadataDescription
+      reportFn(error)
+      if (notification) {
+        notification.dismiss()
       }
     }
 
-    if (error.metadata == null) { error.metadata = {} }
-    error.metadata.bundledPackages = bundledPackages
-    error.metadata.userPackages = userPackages
+    function reportWithPrivateMetadata () {
+      if (error.metadata == null) {
+        error.metadata = {}
+      }
+      for (let key in error.privateMetadata) {
+        let value = error.privateMetadata[key]
+        error.metadata[key] = value
+      }
+      reportWithoutPrivateMetadata()
+    }
+
+    const name = error.privateMetadataRequestName
+    if (name != null) {
+      if (localStorage.getItem(`private-metadata-request:${name}`)) {
+        return reportWithoutPrivateMetadata(error)
+      } else {
+        localStorage.setItem(`private-metadata-request:${name}`, true)
+      }
+    }
+
+    notification = atom.notifications.addInfo(message, {
+      detail: error.privateMetadataDescription,
+      description: "Are you willing to submit this information to a private server for debugging purposes?",
+      dismissable: true,
+      buttons: [
+        {
+          text: "No",
+          onDidClick: reportWithoutPrivateMetadata
+        },
+        {
+          text: "Yes, Submit for Debugging",
+          onDidClick: reportWithPrivateMetadata
+        }
+      ]
+    })
+
+    dismissSubscription = notification.onDidDismiss(reportWithoutPrivateMetadata)
+  }
+
+  addPackageMetadata (error) {
+    let activePackages = atom.packages.getActivePackages()
+    if (activePackages.length > 0) {
+      let userPackages = {}
+      let bundledPackages = {}
+      for (let pack of atom.packages.getActivePackages()) {
+        if (/\/app\.asar\//.test(pack.path)) {
+          bundledPackages[pack.name] = pack.metadata.version
+        } else {
+          userPackages[pack.name] = pack.metadata.version
+        }
+      }
+
+      if (error.metadata == null) { error.metadata = {} }
+      error.metadata.bundledPackages = bundledPackages
+      error.metadata.userPackages = userPackages
+    }
+  }
+
+  reportUncaughtException (error) {
+    if (!this.shouldReport(error)) return
+
+    this.addPackageMetadata(error)
+
+    if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
+      this.requestPrivateMetadataConsent(error, "The Atom team would like to collect the following information to resolve this error:", error => this.reportUncaughtException(error))
+      return
+    }
+
+    let params = this.getDefaultNotificationParams()
+    params.severity = "error"
+    this.performRequest(this.buildNotificationJSON(error, params))
+  }
+
+  reportFailedAssertion (error) {
+    if (!this.shouldReport(error)) return
+
+    this.addPackageMetadata(error)
+
+    if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
+      this.requestPrivateMetadataConsent(error, "The Atom team would like to collect some information to resolve an unexpected condition:", error => this.reportFailedAssertion(error))
+      return
+    }
+
+    let params = this.getDefaultNotificationParams()
+    params.severity = "warning"
+    this.performRequest(this.buildNotificationJSON(error, params))
+  }
+
+  // Used in specs
+  setRequestFunction (requestFunction) {
+    this.request = requestFunction
   }
 }
 
-exports.reportUncaughtException = error => {
-  if (!shouldReport(error)) return
-
-  addPackageMetadata(error)
-
-  if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
-    requestPrivateMetadataConsent(error, "The Atom team would like to collect the following information to resolve this error:", exports.reportUncaughtException)
-    return
-  }
-
-  let params = getDefaultNotificationParams()
-  params.severity = "error"
-  performRequest(buildNotificationJSON(error, params))
-}
-
-exports.reportFailedAssertion = error => {
-  if (!shouldReport(error)) return
-
-  addPackageMetadata(error)
-
-  if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
-    requestPrivateMetadataConsent(error, "The Atom team would like to collect some information to resolve an unexpected condition:", exports.reportFailedAssertion)
-    return
-  }
-
-  let params = getDefaultNotificationParams()
-  params.severity = "warning"
-  performRequest(buildNotificationJSON(error, params))
-}
-
-// Used in specs
-exports.setRequestFunction = (requestFunction) => {
-  request = requestFunction
-}
-
-exports.API_KEY = API_KEY
-exports.LIB_VERSION = LIB_VERSION
+Reporter.API_KEY = API_KEY
+Reporter.LIB_VERSION = LIB_VERSION

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -92,7 +92,7 @@ export default class Reporter {
   }
 
   performRequest (json) {
-    this.request('https://notify.bugsnag.com', {
+    this.request.call(null, 'https://notify.bugsnag.com', {
       method: 'POST',
       headers: new Headers({'Content-Type': 'application/json'}),
       body: JSON.stringify(json)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -13,6 +13,9 @@ export default class Reporter {
   constructor (params = {}) {
     this.request = params.request || window.fetch
     this.alwaysReport = params.hasOwnProperty('alwaysReport') ? params.alwaysReport : false
+    this.reportPreviousErrors = params.hasOwnProperty('reportPreviousErrors') ? params.reportPreviousErrors : true
+    this.reportedErrors = []
+    this.reportedAssertionFailures = []
   }
 
   buildNotificationJSON (error, params) {
@@ -191,10 +194,18 @@ export default class Reporter {
     }
   }
 
+  addPreviousErrorsMetadata (error) {
+    if (!this.reportPreviousErrors) return
+    if (!error.metadata) error.metadata = {}
+    error.metadata.previousErrors = this.reportedErrors.map(error => error.message)
+    error.metadata.previousAssertionFailures = this.reportedAssertionFailures.map(error => error.message)
+  }
+
   reportUncaughtException (error) {
     if (!this.shouldReport(error)) return
 
     this.addPackageMetadata(error)
+    this.addPreviousErrorsMetadata(error)
 
     if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
       this.requestPrivateMetadataConsent(error, "The Atom team would like to collect the following information to resolve this error:", error => this.reportUncaughtException(error))
@@ -204,12 +215,14 @@ export default class Reporter {
     let params = this.getDefaultNotificationParams()
     params.severity = "error"
     this.performRequest(this.buildNotificationJSON(error, params))
+    this.reportedErrors.push(error)
   }
 
   reportFailedAssertion (error) {
     if (!this.shouldReport(error)) return
 
     this.addPackageMetadata(error)
+    this.addPreviousErrorsMetadata(error)
 
     if ((error.privateMetadata != null) && (error.privateMetadataDescription != null)) {
       this.requestPrivateMetadataConsent(error, "The Atom team would like to collect some information to resolve an unexpected condition:", error => this.reportFailedAssertion(error))
@@ -219,6 +232,7 @@ export default class Reporter {
     let params = this.getDefaultNotificationParams()
     params.severity = "warning"
     this.performRequest(this.buildNotificationJSON(error, params))
+    this.reportedAssertionFailures.push(error)
   }
 
   // Used in specs

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -13,9 +13,13 @@ let getReleaseChannel = version => {
 }
 
 describe("Reporter", () => {
-  let [requests, initialStackTraceLimit, mockActivePackages] = []
+  let reporter, requests, initialStackTraceLimit, mockActivePackages
 
   beforeEach(() => {
+    reporter = new Reporter({
+      request: (url, options) => requests.push(Object.assign({url}, options)),
+      alwaysReport: true
+    })
     requests = []
     mockActivePackages = []
     spyOn(atom.packages, 'getActivePackages').andCallFake(() => mockActivePackages)
@@ -23,8 +27,6 @@ describe("Reporter", () => {
     initialStackTraceLimit = Error.stackTraceLimit
     Error.stackTraceLimit = 1
 
-    Reporter.setRequestFunction((url, options) => requests.push(Object.assign({url}, options)))
-    Reporter.alwaysReport = true
   })
 
   afterEach(() => Error.stackTraceLimit = initialStackTraceLimit)
@@ -33,7 +35,7 @@ describe("Reporter", () => {
     it("posts errors to bugsnag", () => {
       let error = new Error()
       Error.captureStackTrace(error)
-      Reporter.reportUncaughtException(error)
+      reporter.reportUncaughtException(error)
       let [lineNumber, columnNumber] = error.stack.match(/.js:(\d+):(\d+)/).slice(1).map(s => parseInt(s))
 
       expect(requests.length).toBe(1)
@@ -101,14 +103,14 @@ describe("Reporter", () => {
       })
 
       it("posts a notification asking for consent", () => {
-        Reporter.reportUncaughtException(error)
+        reporter.reportUncaughtException(error)
         expect(atom.notifications.addInfo).toHaveBeenCalled()
       })
 
       it("submits the error with the private metadata if the user consents", () => {
-        spyOn(Reporter, 'reportUncaughtException').andCallThrough()
-        Reporter.reportUncaughtException(error)
-        Reporter.reportUncaughtException.reset()
+        spyOn(reporter, 'reportUncaughtException').andCallThrough()
+        reporter.reportUncaughtException(error)
+        reporter.reportUncaughtException.reset()
 
         notification = atom.notifications.getNotifications()[0]
 
@@ -116,8 +118,8 @@ describe("Reporter", () => {
         expect(notificationOptions.buttons[1].text).toMatch(/Yes/)
 
         notificationOptions.buttons[1].onDidClick()
-        expect(Reporter.reportUncaughtException).toHaveBeenCalledWith(error)
-        expect(Reporter.reportUncaughtException.callCount).toBe(1)
+        expect(reporter.reportUncaughtException).toHaveBeenCalledWith(error)
+        expect(reporter.reportUncaughtException.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar", baz: "quux"})
@@ -126,9 +128,9 @@ describe("Reporter", () => {
       })
 
       it("submits the error without the private metadata if the user does not consent", () => {
-        spyOn(Reporter, 'reportUncaughtException').andCallThrough()
-        Reporter.reportUncaughtException(error)
-        Reporter.reportUncaughtException.reset()
+        spyOn(reporter, 'reportUncaughtException').andCallThrough()
+        reporter.reportUncaughtException(error)
+        reporter.reportUncaughtException.reset()
 
         notification = atom.notifications.getNotifications()[0]
 
@@ -136,8 +138,8 @@ describe("Reporter", () => {
         expect(notificationOptions.buttons[0].text).toMatch(/No/)
 
         notificationOptions.buttons[0].onDidClick()
-        expect(Reporter.reportUncaughtException).toHaveBeenCalledWith(error)
-        expect(Reporter.reportUncaughtException.callCount).toBe(1)
+        expect(reporter.reportUncaughtException).toHaveBeenCalledWith(error)
+        expect(reporter.reportUncaughtException.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar"})
@@ -146,15 +148,15 @@ describe("Reporter", () => {
       })
 
       it("submits the error without the private metadata if the user dismisses the notification", () => {
-        spyOn(Reporter, 'reportUncaughtException').andCallThrough()
-        Reporter.reportUncaughtException(error)
-        Reporter.reportUncaughtException.reset()
+        spyOn(reporter, 'reportUncaughtException').andCallThrough()
+        reporter.reportUncaughtException(error)
+        reporter.reportUncaughtException.reset()
 
         notification = atom.notifications.getNotifications()[0]
         notification.dismiss()
 
-        expect(Reporter.reportUncaughtException).toHaveBeenCalledWith(error)
-        expect(Reporter.reportUncaughtException.callCount).toBe(1)
+        expect(reporter.reportUncaughtException).toHaveBeenCalledWith(error)
+        expect(reporter.reportUncaughtException.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar"});});})
@@ -169,7 +171,7 @@ describe("Reporter", () => {
 
       let error = new Error()
       Error.captureStackTrace(error)
-      Reporter.reportUncaughtException(error)
+      reporter.reportUncaughtException(error)
 
       expect(error.metadata.userPackages).toEqual({
         'user-1': '1.0.0',
@@ -186,7 +188,7 @@ describe("Reporter", () => {
     it("posts warnings to bugsnag", () => {
       let error = new Error()
       Error.captureStackTrace(error)
-      Reporter.reportFailedAssertion(error)
+      reporter.reportFailedAssertion(error)
       let [lineNumber, columnNumber] = error.stack.match(/.js:(\d+):(\d+)/).slice(1).map(s => parseInt(s))
 
       expect(requests.length).toBe(1)
@@ -254,14 +256,14 @@ describe("Reporter", () => {
       })
 
       it("posts a notification asking for consent", () => {
-        Reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion(error)
         expect(atom.notifications.addInfo).toHaveBeenCalled()
       })
 
       it("submits the error with the private metadata if the user consents", () => {
-        spyOn(Reporter, 'reportFailedAssertion').andCallThrough()
-        Reporter.reportFailedAssertion(error)
-        Reporter.reportFailedAssertion.reset()
+        spyOn(reporter, 'reportFailedAssertion').andCallThrough()
+        reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion.reset()
 
         notification = atom.notifications.getNotifications()[0]
 
@@ -269,8 +271,8 @@ describe("Reporter", () => {
         expect(notificationOptions.buttons[1].text).toMatch(/Yes/)
 
         notificationOptions.buttons[1].onDidClick()
-        expect(Reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
-        expect(Reporter.reportFailedAssertion.callCount).toBe(1)
+        expect(reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
+        expect(reporter.reportFailedAssertion.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar", baz: "quux"})
@@ -279,9 +281,9 @@ describe("Reporter", () => {
       })
 
       it("submits the error without the private metadata if the user does not consent", () => {
-        spyOn(Reporter, 'reportFailedAssertion').andCallThrough()
-        Reporter.reportFailedAssertion(error)
-        Reporter.reportFailedAssertion.reset()
+        spyOn(reporter, 'reportFailedAssertion').andCallThrough()
+        reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion.reset()
 
         notification = atom.notifications.getNotifications()[0]
 
@@ -289,8 +291,8 @@ describe("Reporter", () => {
         expect(notificationOptions.buttons[0].text).toMatch(/No/)
 
         notificationOptions.buttons[0].onDidClick()
-        expect(Reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
-        expect(Reporter.reportFailedAssertion.callCount).toBe(1)
+        expect(reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
+        expect(reporter.reportFailedAssertion.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar"})
@@ -299,15 +301,15 @@ describe("Reporter", () => {
       })
 
       it("submits the error without the private metadata if the user dismisses the notification", () => {
-        spyOn(Reporter, 'reportFailedAssertion').andCallThrough()
-        Reporter.reportFailedAssertion(error)
-        Reporter.reportFailedAssertion.reset()
+        spyOn(reporter, 'reportFailedAssertion').andCallThrough()
+        reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion.reset()
 
         notification = atom.notifications.getNotifications()[0]
         notification.dismiss()
 
-        expect(Reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
-        expect(Reporter.reportFailedAssertion.callCount).toBe(1)
+        expect(reporter.reportFailedAssertion).toHaveBeenCalledWith(error)
+        expect(reporter.reportFailedAssertion.callCount).toBe(1)
         expect(error.privateMetadata).toBeUndefined()
         expect(error.privateMetadataDescription).toBeUndefined()
         expect(error.metadata).toEqual({foo: "bar"})
@@ -320,11 +322,11 @@ describe("Reporter", () => {
 
         error.privateMetadataRequestName = 'foo'
 
-        Reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion(error)
         expect(atom.notifications.addInfo).toHaveBeenCalled()
         atom.notifications.addInfo.reset()
 
-        Reporter.reportFailedAssertion(error)
+        reporter.reportFailedAssertion(error)
         expect(atom.notifications.addInfo).not.toHaveBeenCalled()
 
         let error2 = new Error()
@@ -333,7 +335,7 @@ describe("Reporter", () => {
         error2.privateMetadata = {baz: 'quux'}
         error2.privateMetadataRequestName = 'bar'
 
-        Reporter.reportFailedAssertion(error2)
+        reporter.reportFailedAssertion(error2)
         expect(atom.notifications.addInfo).toHaveBeenCalled()
       })
     })
@@ -348,7 +350,7 @@ describe("Reporter", () => {
 
       let error = new Error()
       Error.captureStackTrace(error)
-      Reporter.reportFailedAssertion(error)
+      reporter.reportFailedAssertion(error)
 
       expect(error.metadata.userPackages).toEqual({
         'user-1': '1.0.0',

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -18,7 +18,8 @@ describe("Reporter", () => {
   beforeEach(() => {
     reporter = new Reporter({
       request: (url, options) => requests.push(Object.assign({url}, options)),
-      alwaysReport: true
+      alwaysReport: true,
+      reportPreviousErrors: false
     })
     requests = []
     mockActivePackages = []
@@ -181,6 +182,26 @@ describe("Reporter", () => {
         'bundled-1': '1.0.0',
         'bundled-2': '1.2.0'
       })
+    })
+
+    it('adds previous error messages and assertion failures to the reported metadata', () => {
+      reporter.reportPreviousErrors = true
+
+      reporter.reportUncaughtException(new Error('A'))
+      reporter.reportUncaughtException(new Error('B'))
+      reporter.reportFailedAssertion(new Error('X'))
+      reporter.reportFailedAssertion(new Error('Y'))
+
+      reporter.reportUncaughtException(new Error('C'))
+
+      expect(requests.length).toBe(5)
+
+      const lastRequest = requests[requests.length - 1]
+      const body = JSON.parse(lastRequest.body)
+
+      console.log(body);
+      expect(body.events[0].metaData.previousErrors).toEqual(['A', 'B'])
+      expect(body.events[0].metaData.previousAssertionFailures).toEqual(['X', 'Y'])
     })
   })
 
@@ -360,6 +381,26 @@ describe("Reporter", () => {
         'bundled-1': '1.0.0',
         'bundled-2': '1.2.0'
       })
+    })
+
+    it('adds previous error messages and assertion failures to the reported metadata', () => {
+      reporter.reportPreviousErrors = true
+
+      reporter.reportUncaughtException(new Error('A'))
+      reporter.reportUncaughtException(new Error('B'))
+      reporter.reportFailedAssertion(new Error('X'))
+      reporter.reportFailedAssertion(new Error('Y'))
+
+      reporter.reportFailedAssertion(new Error('C'))
+
+      expect(requests.length).toBe(5)
+
+      const lastRequest = requests[requests.length - 1]
+      const body = JSON.parse(lastRequest.body)
+
+      console.log(body);
+      expect(body.events[0].metaData.previousErrors).toEqual(['A', 'B'])
+      expect(body.events[0].metaData.previousAssertionFailures).toEqual(['X', 'Y'])
     })
   })
 })


### PR DESCRIPTION
If an exception occurs in Atom, any subsequent interaction is fairly suspect because the code path in which the previous exception occurred didn't terminate cleanly, potentially leaving us in an invalid state. It's important that we know whether a given exception occurred *after* some other exception to ensure we focus on the root cause of an issue rather than random downstream consequences.

This PR adds the messages associated with previous errors and assertion failures to the metadata of every error. This should occur as a tab in bug snag containing a list. I'm not adding the full stack traces because I'm worried about bugsnag rejecting our metadata for being too large. This should at least give us a *sense* of what's going on however.

This PR also refactors reporter to be a proper class rather than a bunch of free functions so it's easier to test.

![bugsnag](https://cloud.githubusercontent.com/assets/1789/22835746/0e7be398-ef77-11e6-8b5b-5692399d0728.gif)

/cc @ungb @maxbrunsfeld 