### PR TITLE
Don't use babel in spec/reporter-spec.js

### DIFF
--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -1,7 +1,5 @@
-/** @babel */
-
-import Reporter from '../lib/reporter'
-import os from 'os'
+const Reporter = require('../lib/reporter')
+const os = require('os')
 let osVersion = `${os.platform()}-${os.arch()}-${os.release()}`
 
 let getReleaseChannel = version => {
@@ -68,7 +66,7 @@ describe("Reporter", () => {
                 "message": "",
                 "stacktrace": [
                   {
-                    "method": ".<anonymous>",
+                    "method": "it",
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber
                   }
@@ -241,7 +239,7 @@ describe("Reporter", () => {
                 "message": "",
                 "stacktrace": [
                   {
-                    "method": ".<anonymous>",
+                    "method": "it",
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber
                   }


### PR DESCRIPTION
This fixes a false negative that we are getting in https://github.com/atom/atom/pull/13823. Since we don't transpile arrow functions anymore, stack traces look saner too and, as a result, we need to change the assertion that checks what we report to bugsnag.