### PR TITLE
Fix tests on Electron >= 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "node-uuid": "~1.4.7",
     "stack-trace": "0.0.9",
     "underscore-plus": "1.x"
+  },
+  "devDependencies": {
+    "semver": "^5.3.0"
   }
 }

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -1,4 +1,5 @@
 const Reporter = require('../lib/reporter')
+const semver = require('semver')
 const os = require('os')
 let osVersion = `${os.platform()}-${os.arch()}-${os.release()}`
 
@@ -66,7 +67,7 @@ describe("Reporter", () => {
                 "message": "",
                 "stacktrace": [
                   {
-                    "method": "it",
+                    "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber
                   }
@@ -239,7 +240,7 @@ describe("Reporter", () => {
                 "message": "",
                 "stacktrace": [
                   {
-                    "method": "it",
+                    "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber
                   }


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/13880

Using a newer electron version causes stack traces to look slightly different, thus making some of our tests fail.

This pull request updates the tests to use the correct stack trace when using Electron >= 1.6.