### PR TITLE
Ensure user packages are separated from bundled packages

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -4,6 +4,7 @@ import _ from 'underscore-plus'
 import os from 'os'
 import stackTrace from 'stack-trace'
 import fs from 'fs-plus'
+import path from 'path'
 
 const API_KEY = '7ddca14cb60cbd1cd12d1b252473b076'
 const LIB_VERSION = require('../package.json')['version']
@@ -177,11 +178,12 @@ export default class Reporter {
 
   addPackageMetadata (error) {
     let activePackages = atom.packages.getActivePackages()
+    const availablePackagePaths = atom.packages.getPackageDirPaths()
     if (activePackages.length > 0) {
       let userPackages = {}
       let bundledPackages = {}
       for (let pack of atom.packages.getActivePackages()) {
-        if (/\/app\.asar\//.test(pack.path)) {
+        if (atom.packages.isBundledPackage(pack.name) && !availablePackagePaths.includes(path.dirname(pack.path))) {
           bundledPackages[pack.name] = pack.metadata.version
         } else {
           userPackages[pack.name] = pack.metadata.version

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "fs-plus": "^3.0.0",
     "node-uuid": "~1.4.7",
+    "path": "^0.12.7",
     "stack-trace": "0.0.9",
     "underscore-plus": "1.x"
   },

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -169,6 +169,16 @@ describe("Reporter", () => {
         {name: 'bundled-2', path: '/Applications/Atom.app/Contents/Resources/app.asar/node_modules/bundled-2', metadata: {version: '1.2.0'}},
       ]
 
+      const bundledPackages = [
+        'bundled-1',
+        'bundled-2'
+      ]
+
+      const packageDirPaths = ['/Users/user/.atom/packages']
+
+      spyOn(atom.packages, 'isBundledPackage').andCallFake((name) => bundledPackages.includes(name))
+      spyOn(atom.packages, 'getPackageDirPaths').andCallFake(() => packageDirPaths)
+
       let error = new Error()
       Error.captureStackTrace(error)
       reporter.reportUncaughtException(error)
@@ -179,6 +189,38 @@ describe("Reporter", () => {
       })
       expect(error.metadata.bundledPackages).toEqual({
         'bundled-1': '1.0.0',
+        'bundled-2': '1.2.0'
+      })
+    })
+
+    it("adds manually installed bundled packages to the error's userPackages metadata", () => {
+      mockActivePackages = [
+        {name: 'user-1', path: '/Users/user/.atom/packages/user-1', metadata: {version: '1.0.0'}},
+        {name: 'user-2', path: '/Users/user/.atom/packages/user-2', metadata: {version: '1.2.0'}},
+        {name: 'bundled-1', path: '/Users/user/.atom/packages/bundled-1', metadata: {version: '1.2.0'}},
+        {name: 'bundled-2', path: '/Applications/Atom.app/Contents/Resources/app.asar/node_modules/bundled-2', metadata: {version: '1.2.0'}},
+      ]
+
+      const bundledPackages = [
+        'bundled-1',
+        'bundled-2'
+      ]
+
+      const packageDirPaths = ['/Users/user/.atom/packages']
+
+      spyOn(atom.packages, 'isBundledPackage').andCallFake((name) => bundledPackages.includes(name))
+      spyOn(atom.packages, 'getPackageDirPaths').andCallFake(() => packageDirPaths)
+
+      let error = new Error()
+      Error.captureStackTrace(error)
+      reporter.reportUncaughtException(error)
+
+      expect(error.metadata.userPackages).toEqual({
+        'user-1': '1.0.0',
+        'user-2': '1.2.0',
+        'bundled-1': '1.2.0'
+      })
+      expect(error.metadata.bundledPackages).toEqual({
         'bundled-2': '1.2.0'
       })
     })
@@ -368,6 +410,16 @@ describe("Reporter", () => {
         {name: 'bundled-2', path: '/Applications/Atom.app/Contents/Resources/app.asar/node_modules/bundled-2', metadata: {version: '1.2.0'}},
       ]
 
+      const bundledPackages = [
+        'bundled-1',
+        'bundled-2'
+      ]
+
+      const packageDirPaths = ['/Users/user/.atom/packages']
+
+      spyOn(atom.packages, 'isBundledPackage').andCallFake((name) => bundledPackages.includes(name))
+      spyOn(atom.packages, 'getPackageDirPaths').andCallFake(() => packageDirPaths)
+
       let error = new Error()
       Error.captureStackTrace(error)
       reporter.reportFailedAssertion(error)
@@ -379,6 +431,38 @@ describe("Reporter", () => {
       expect(error.metadata.bundledPackages).toEqual({
         'bundled-1': '1.0.0',
         'bundled-2': '1.2.0'
+      })
+    })
+
+    it("adds manually installed bundled packages to the error's userPackages metadata", () => {
+      mockActivePackages = [
+        {name: 'user-1', path: '/Users/user/.atom/packages/user-1', metadata: {version: '1.0.0'}},
+        {name: 'user-2', path: '/Users/user/.atom/packages/user-2', metadata: {version: '1.2.0'}},
+        {name: 'bundled-1', path: '/Users/user/.atom/packages/bundled-1', metadata: {version: '1.2.0'}},
+        {name: 'bundled-2', path: '/Applications/Atom.app/Contents/Resources/app.asar/node_modules/bundled-2', metadata: {version: '1.2.0'}},
+      ]
+
+      const bundledPackages = [
+        'bundled-1',
+        'bundled-2'
+      ]
+
+      const packageDirPaths = ['/Users/user/.atom/packages']
+
+      spyOn(atom.packages, 'isBundledPackage').andCallFake((name) => bundledPackages.includes(name))
+      spyOn(atom.packages, 'getPackageDirPaths').andCallFake(() => packageDirPaths)
+
+      let error = new Error()
+      Error.captureStackTrace(error)
+      reporter.reportFailedAssertion(error)
+
+      expect(error.metadata.userPackages).toEqual({
+        'user-1': '1.0.0',
+        'user-2': '1.2.0',
+        'bundled-1': '1.2.0'
+      })
+      expect(error.metadata.bundledPackages).toEqual({
+        'bundled-2': '1.2.0',
       })
     })
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The previous check for bundled and user packages was checking for the existence of `app.asar`. This means it stopped working when we removed the asar. The regex also only worked for paths with forward slashes so it didn't work on Windows.

### Alternate Designs

Did not consider any alternative designs

### Benefits

Fixes exception reporting so User packages and Bundled packages are separated

### Possible Drawbacks

Introduces path as a dependency

### Applicable Issues

Fixes https://github.com/atom/exception-reporting/issues/36

/cc: @nathansobo for review

Shoutouts to @50Wliu for helping me through some major git problems and for bouncing ideas while I was being tired and confused.