### PR TITLE
Report uncaught exceptions occurring on the Teletype package

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -105,10 +105,9 @@ export default class Reporter {
     if (atom.config.get('core.telemetryConsent') !== 'limited') return false
     if (atom.inDevMode()) return false
 
-    let topFrame = this.parseStackTrace(error)[0]
-    return topFrame &&
-           topFrame.getFileName() &&
-           topFrame.getFileName().indexOf(atom.getLoadSettings().resourcePath) === 0
+    const topFrame = this.parseStackTrace(error)[0]
+    const fileName = topFrame ? topFrame.getFileName() : null
+    return fileName && (isBundledFile(fileName) || isTeletypeFile(fileName))
   }
 
   parseStackTrace (error) {
@@ -241,6 +240,15 @@ export default class Reporter {
   setRequestFunction (requestFunction) {
     this.request = requestFunction
   }
+}
+
+function isBundledFile (fileName) {
+  return fileName.indexOf(atom.getLoadSettings().resourcePath) === 0
+}
+
+function isTeletypeFile (fileName) {
+  const teletypePath = atom.packages.resolvePackagePath('teletype')
+  return teletypePath && fileName.indexOf(teletypePath) === 0
 }
 
 Reporter.API_KEY = API_KEY


### PR DESCRIPTION
This will allow us to get a sense of what and how many exceptions are thrown in the Teletype package even if it is not yet bundled in Atom Core.

To test this, I created a fake exception on the Teletype package and verified it was correctly reported to [BugSnag](https://app.bugsnag.com/atom/atom/errors/5a1534a9991ca70018e867cd?filters%5Bevent.since%5D%5B%5D=30d&filters%5Berror.status%5D%5B%5D=open). I think we should hotfix this to stable and beta so that we can start gathering information without having to wait for a full release cycle.

/cc: @atom/maintainers 