### PR TITLE
Improve path normalization

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -79,9 +79,8 @@ export default class Reporter {
     if (this.isBundledFile(absolutePath)) {
       return this.normalizePath(path.relative(this.resourcePath, absolutePath))
     } else {
-      const homeDirPath = fs.getHomeDirectory().replace(/\\/g, '/')
       return absolutePath
-        .replace(homeDirPath, '~') // Remove users home dir
+        .replace(this.normalizePath(fs.getHomeDirectory()), '~') // Remove users home dir
         .replace(/.*(\/packages\/.*)/, '$1') // Remove everything before app.asar or packages
     }
   }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,6 +15,7 @@ export default class Reporter {
     this.request = params.request || window.fetch
     this.alwaysReport = params.hasOwnProperty('alwaysReport') ? params.alwaysReport : false
     this.reportPreviousErrors = params.hasOwnProperty('reportPreviousErrors') ? params.reportPreviousErrors : true
+    this.resourcePath = params.resourcePath ? params.resourcePath : atom.getLoadSettings().resourcePath
     this.reportedErrors = []
     this.reportedAssertionFailures = []
   }
@@ -66,12 +67,17 @@ export default class Reporter {
     })
   }
 
-  normalizePath (path) {
-    return path.replace('file:///', '')                         // Randomly inserted file url protocols
-               .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
-               .replace(fs.getHomeDirectory(), '~')             // Remove users home dir for apm-dev'ed packages
-               .replace(/\\/g, '/')                             // Switch \ back to / for everyone
-               .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
+  normalizePath (pathToNormalize) {
+    const absolutePath = pathToNormalize.replace('file:///', '')
+    if (this.isBundledFile(absolutePath)) {
+      return path.relative(this.resourcePath, absolutePath)
+    } else {
+      return absolutePath
+        .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
+        .replace(fs.getHomeDirectory(), '~')             // Remove users home dir for apm-dev'ed packages
+        .replace(/\\/g, '/')                             // Switch \ back to / for everyone
+        .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
+    }
   }
 
   getDefaultNotificationParams () {
@@ -107,7 +113,7 @@ export default class Reporter {
 
     const topFrame = this.parseStackTrace(error)[0]
     const fileName = topFrame ? topFrame.getFileName() : null
-    return fileName && (isBundledFile(fileName) || isTeletypeFile(fileName))
+    return fileName && (this.isBundledFile(fileName) || this.isTeletypeFile(fileName))
   }
 
   parseStackTrace (error) {
@@ -240,16 +246,17 @@ export default class Reporter {
   setRequestFunction (requestFunction) {
     this.request = requestFunction
   }
+
+  isBundledFile (fileName) {
+    return fileName.indexOf(this.resourcePath) === 0
+  }
+
+  isTeletypeFile (fileName) {
+    const teletypePath = atom.packages.resolvePackagePath('teletype')
+    return teletypePath && fileName.indexOf(teletypePath) === 0
+  }
 }
 
-function isBundledFile (fileName) {
-  return fileName.indexOf(atom.getLoadSettings().resourcePath) === 0
-}
-
-function isTeletypeFile (fileName) {
-  const teletypePath = atom.packages.resolvePackagePath('teletype')
-  return teletypePath && fileName.indexOf(teletypePath) === 0
-}
 
 Reporter.API_KEY = API_KEY
 Reporter.LIB_VERSION = LIB_VERSION

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,7 +15,7 @@ export default class Reporter {
     this.request = params.request || window.fetch
     this.alwaysReport = params.hasOwnProperty('alwaysReport') ? params.alwaysReport : false
     this.reportPreviousErrors = params.hasOwnProperty('reportPreviousErrors') ? params.reportPreviousErrors : true
-    this.resourcePath = this.normalizePath(params.resourcePath || atom.getLoadSettings().resourcePath)
+    this.resourcePath = this.normalizePath(params.resourcePath || process.resourcesPath)
     this.reportedErrors = []
     this.reportedAssertionFailures = []
   }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,7 +15,7 @@ export default class Reporter {
     this.request = params.request || window.fetch
     this.alwaysReport = params.hasOwnProperty('alwaysReport') ? params.alwaysReport : false
     this.reportPreviousErrors = params.hasOwnProperty('reportPreviousErrors') ? params.reportPreviousErrors : true
-    this.resourcePath = params.resourcePath ? params.resourcePath : atom.getLoadSettings().resourcePath
+    this.resourcePath = this.normalizePath(params.resourcePath || atom.getLoadSettings().resourcePath)
     this.reportedErrors = []
     this.reportedAssertionFailures = []
   }
@@ -58,7 +58,7 @@ export default class Reporter {
   buildStackTraceJSON (error, projectRoot) {
     return this.parseStackTrace(error).map(callSite => {
       return {
-        file: this.normalizePath(callSite.getFileName()),
+        file: this.scrubPath(callSite.getFileName()),
         method: callSite.getMethodName() || callSite.getFunctionName() || "none",
         lineNumber: callSite.getLineNumber(),
         columnNumber: callSite.getColumnNumber(),
@@ -68,20 +68,22 @@ export default class Reporter {
   }
 
   normalizePath (pathToNormalize) {
-    const absolutePath = pathToNormalize.replace('file:///', '')
-    let relativePath
-    if (this.isBundledFile(absolutePath)) {
-      relativePath = path.relative(this.resourcePath, absolutePath)
-    } else {
-      const homeDirPath = fs.getHomeDirectory()
-      relativePath = absolutePath
-        .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
-        .replace(homeDirPath.replace(/[/]/g, '\\'), '~') // Remove users home dir
-        .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
-    }
+    return pathToNormalize
+      .replace('file:///', '')  // Sometimes it's a uri
+      .replace(/\\/g, '/')      // Unify path separators across Win/macOS/Linux
+  }
 
-    // Use forward slashes for all platforms
-    return relativePath.replace(/\\/g, '/')
+  scrubPath (pathToScrub) {
+    const absolutePath = this.normalizePath(pathToScrub)
+
+    if (this.isBundledFile(absolutePath)) {
+      return this.normalizePath(path.relative(this.resourcePath, absolutePath))
+    } else {
+      const homeDirPath = fs.getHomeDirectory().replace(/\\/g, '/')
+      return absolutePath
+        .replace(homeDirPath, '~') // Remove users home dir
+        .replace(/.*(\/packages\/.*)/, '$1') // Remove everything before app.asar or packages
+    }
   }
 
   getDefaultNotificationParams () {
@@ -252,12 +254,12 @@ export default class Reporter {
   }
 
   isBundledFile (fileName) {
-    return fileName.indexOf(this.resourcePath) === 0
+    return this.normalizePath(fileName).indexOf(this.resourcePath) === 0
   }
 
   isTeletypeFile (fileName) {
     const teletypePath = atom.packages.resolvePackagePath('teletype')
-    return teletypePath && fileName.indexOf(teletypePath) === 0
+    return teletypePath && this.normalizePath(fileName).indexOf(teletypePath) === 0
   }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -69,15 +69,19 @@ export default class Reporter {
 
   normalizePath (pathToNormalize) {
     const absolutePath = pathToNormalize.replace('file:///', '')
+    let relativePath
     if (this.isBundledFile(absolutePath)) {
-      return path.relative(this.resourcePath, absolutePath)
+      relativePath = path.relative(this.resourcePath, absolutePath)
     } else {
-      return absolutePath
+      const homeDirPath = fs.getHomeDirectory()
+      relativePath = absolutePath
         .replace(/[/]/g, '\\')                           // Temp switch for Windows home matching
-        .replace(fs.getHomeDirectory(), '~')             // Remove users home dir for apm-dev'ed packages
-        .replace(/\\/g, '/')                             // Switch \ back to / for everyone
+        .replace(homeDirPath.replace(/[/]/g, '\\'), '~') // Remove users home dir
         .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') // Remove everything before app.asar or pacakges
     }
+
+    // Use forward slashes for all platforms
+    return relativePath.replace(/\\/g, '/')
   }
 
   getDefaultNotificationParams () {

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -458,7 +458,6 @@ describe("Reporter", () => {
       const lastRequest = requests[requests.length - 1]
       const body = JSON.parse(lastRequest.body)
 
-      console.log(body);
       expect(body.events[0].metaData.previousErrors).toEqual(['A', 'B'])
       expect(body.events[0].metaData.previousAssertionFailures).toEqual(['X', 'Y'])
     })

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -14,7 +14,7 @@ let getReleaseChannel = version => {
 }
 
 describe("Reporter", () => {
-  let reporter, requests, initialStackTraceLimit, mockActivePackages
+  let reporter, requests, initialStackTraceLimit, initialFsGetHomeDirectory, mockActivePackages
 
   beforeEach(() => {
     reporter = new Reporter({
@@ -29,9 +29,13 @@ describe("Reporter", () => {
     initialStackTraceLimit = Error.stackTraceLimit
     Error.stackTraceLimit = 1
 
+    initialFsGetHomeDirectory = fs.getHomeDirectory
   })
 
-  afterEach(() => Error.stackTraceLimit = initialStackTraceLimit)
+  afterEach(() => {
+    fs.getHomeDirectory = initialFsGetHomeDirectory
+    Error.stackTraceLimit = initialStackTraceLimit
+  })
 
   describe(".reportUncaughtException(error)", () => {
     it("posts errors originated inside Atom Core to BugSnag", () => {
@@ -94,6 +98,8 @@ describe("Reporter", () => {
       });})
 
     it("posts errors originated outside Atom Core to BugSnag", () => {
+      fs.getHomeDirectory = () => path.join(__dirname, '..', '..')
+
       let error = new Error()
       Error.captureStackTrace(error)
       reporter.reportUncaughtException(error)
@@ -123,7 +129,7 @@ describe("Reporter", () => {
                 "stacktrace": [
                   {
                     "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
-                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)).replace(/\\/g, '/'),
+                    "file": '~/exception-reporting/spec/reporter-spec.js',
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber,
                     "inProject": true
@@ -267,6 +273,8 @@ describe("Reporter", () => {
 
   describe(".reportFailedAssertion(error)", () => {
     it("posts warnings to bugsnag", () => {
+      fs.getHomeDirectory = () => path.join(__dirname, '..', '..')
+
       let error = new Error()
       Error.captureStackTrace(error)
       reporter.reportFailedAssertion(error)
@@ -296,7 +304,7 @@ describe("Reporter", () => {
                 "stacktrace": [
                   {
                     "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
-                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)).replace(/\\/g, '/'),
+                    "file": '~/exception-reporting/spec/reporter-spec.js',
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber,
                     "inProject": true

--- a/spec/reporter-spec.js
+++ b/spec/reporter-spec.js
@@ -123,7 +123,7 @@ describe("Reporter", () => {
                 "stacktrace": [
                   {
                     "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
-                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)),
+                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)).replace(/\\/g, '/'),
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber,
                     "inProject": true
@@ -296,7 +296,7 @@ describe("Reporter", () => {
                 "stacktrace": [
                   {
                     "method": semver.gt(process.versions.electron, '1.6.0') ? 'Spec.it' : 'it',
-                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)),
+                    "file": path.join('~', path.relative(fs.getHomeDirectory(), __filename)).replace(/\\/g, '/'),
                     "lineNumber": lineNumber,
                     "columnNumber": columnNumber,
                     "inProject": true


### PR DESCRIPTION
### Description of the Change

This pull request contains a few improvements to this package:

* 26c77d4 relativizes all stack traces that originate from a file that is part of Atom Core. By doing so, we will eliminate duplicate entries on BugSnag that logically refer to the same code path.
* bdd759e enhances existing tests and introduces new ones to ensure the normalization code path works correctly both when exceptions are triggered from Atom Core *and* when they aren't.
* 764a883 addresses an issue discovered via the above tests that was preventing files outside of Atom Core from being normalized from `/home-directory/foo/bar` to `~/foo/bar`, causing further duplication on BugSnag.

### Alternate Designs

None.

### Benefits

Prevents stack traces that logically belong to the same call site from being duplicated on BugSnag.

### Possible Drawbacks

Unclear.

### Applicable Issues

Fixes #35