### PR TITLE
Update README to deprecate repository and redirect readers to atom/atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/exception-reporting), please direct all issues and pull requests there in the future!
+
+---
+
 ## Exception Reporting package
 [![macOS Build Status](https://travis-ci.org/atom/exception-reporting.svg?branch=master)](https://travis-ci.org/atom/exception-reporting) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/i0pla7qbpv7celg2/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/exception-reporting/branch/master) [![Dependency Status](https://david-dm.org/atom/exception-reporting.svg)](https://david-dm.org/atom/exception-reporting)
 


### PR DESCRIPTION
As of atom/atom#18140, the `exception-reporting` package is now a part of the core Atom repository. This pull request updates `README.md` to reflect that fact. We'll be archiving this repository shortly.

/cc atom/atom#17842